### PR TITLE
Skip downloading Spark files when integration tests are skipped

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -236,6 +236,7 @@
               <url>${spark.bin.download.url}</url>
               <outputDirectory>${project.build.directory}</outputDirectory>
               <unpack>true</unpack>
+              <skip>${skipITs}</skip>
             </configuration>
           </execution>
         </executions>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -242,6 +242,7 @@
               <url>${spark.bin.download.url}</url>
               <outputDirectory>${project.build.directory}</outputDirectory>
               <unpack>true</unpack>
+              <skip>${skipITs}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
To speed up the building process.