### PR TITLE
Use `appTag` label filter for `getAppFromTag` method

### DIFF
--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -63,7 +63,7 @@ class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite {
       when(mockAppReport.getApplicationDiagnostics).thenReturn(IndexedSeq("app", "diagnostics"))
       when(mockAppReport.getTrackingUrl).thenReturn(Some(trackingUrl))
       val mockClient = mock[LivyKubernetesClient]
-      when(mockClient.getApplications(any(), any(), any())).thenReturn(Seq(mockApp))
+      when(mockClient.getApplications(anyString())).thenReturn(Seq(mockApp))
       when(mockClient.getApplicationReport(eqs(mockApp), any(), any())).thenReturn(mockAppReport)
 
       // Simulate Kubernetes app state progression.
@@ -101,7 +101,7 @@ class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite {
           app.kubernetesAppMonitorThread.join(TEST_TIMEOUT.toMillis)
           assert(!app.kubernetesAppMonitorThread.isAlive,
             "KubernetesAppMonitorThread should terminate after Kubernetes app is finished")
-          verify(mockClient, atLeast(1)).getApplications(any(), anyString(), anyString())
+          verify(mockClient, atLeast(1)).getApplications(anyString())
           verify(mockClient, atLeast(1))
             .getApplicationReport(eqs(mockApp), anyInt(), anyString())
           verify(mockListener).appIdKnown(appId)


### PR DESCRIPTION
The current approach gets all the apps from K8s and then filter by `appTag` locally to get the target apps. This will put much pressure on K8s API server when there are lots of Spark apps.

This commit overrides the `getApplications` method to support `appTag` label as filter. With the new method it will be a server side filter and K8s API will only return apps with the target `appTag`.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
