### PR TITLE
Add new configuration livy.server.recovery.persist-success-sessions

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -236,6 +236,16 @@ object LivyConf {
   val RECOVERY_ZK_STATE_STORE_KEY_PREFIX =
     Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
 
+  /**
+   * Whether to persist successful sessions and recover them when Livy restarts.
+   * Note: In Kubernetes environments, when there are thousands of successful sessions to recover,
+   * the Kube API could be exhausted, potentially leading to performance issues or failures during
+   * recovery.
+   * Default value is true.
+   */
+  val RECOVERY_PERSIST_SUCCESS_SESSIONS =
+    Entry("livy.server.recovery.persist-success-sessions", true)
+
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -187,7 +187,12 @@ class BatchSession(
           _state = SessionState.Running
           info(s"Batch session $id created [appid: ${appId.orNull}, state: ${state.toString}, " +
             s"info: ${appInfo.asJavaMap}]")
-        case SparkApp.State.FINISHED => _state = SessionState.Success()
+        case SparkApp.State.FINISHED => {
+          _state = SessionState.Success()
+          if (!livyConf.getBoolean(LivyConf.RECOVERY_PERSIST_SUCCESS_SESSIONS)) {
+            sessionStore.remove(RECOVERY_SESSION_TYPE, id)
+          }
+        }
         case SparkApp.State.KILLED => {
           _state = SessionState.Killed()
           sessionStore.remove(RECOVERY_SESSION_TYPE, id)


### PR DESCRIPTION
The new configuration is used to decide whether to persist successful sessions and recover them when Livy restarts.

Note: In Kubernetes environments, when there are thousands of successful sessions to recover, the Kube API could be exhausted, potentially leading to performance issues or failures during recovery.

Default value is true. Set it to false when necessary.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
