### PR TITLE
Fix `RSCConf#isRunningOnKubernetes` logic for RSCDriver

### DIFF
--- a/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/RSCConf.java
@@ -152,12 +152,6 @@ public class RSCConf extends ClientConf<RSCConf> {
     return address.getCanonicalHostName();
   }
 
-  public boolean isRunningOnKubernetes() {
-    return Optional.ofNullable(get("livy.spark.master"))
-            .filter(s -> s.startsWith("k8s"))
-            .isPresent();
-  }
-
   private static final Map<String, DeprecatedConf> configsWithAlternatives
     = Collections.unmodifiableMap(new HashMap<String, DeprecatedConf>() {{
       put(RSCConf.Entry.CLIENT_IN_PROCESS.key, DepConf.CLIENT_IN_PROCESS);

--- a/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/org/apache/livy/rsc/driver/RSCDriver.java
@@ -172,7 +172,7 @@ public class RSCDriver extends BaseProtocol {
     // If we are running on Kubernetes, set RPC_SERVER_ADDRESS from "spark.driver.host" option,
     // which is set in class org.apache.spark.deploy.k8s.features.DriverServiceFeatureStep:
     // line 61: val driverHostname = s"$resolvedServiceName.${kubernetesConf.namespace()}.svc"
-    if (livyConf.isRunningOnKubernetes()) {
+    if (conf.get("spark.master").startsWith("k8s")) {
       livyConf.set(RPC_SERVER_ADDRESS, conf.get("spark.driver.host"));
     }
 


### PR DESCRIPTION
The method `RSCConf#isRunningOnKubernetes` always returns false, since `livy.spark.master` will not be get by `RSCConf`. The only useage of this method is for setting `RPC_SERVER_ADDRESS` in `RSCDriver` when Spark's running on Kubernetes, and it's causing Spark driver to fail in interactive mode.

Let's remove this bug method, and use Spark conf directly to check if it's running on Kubernetes.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
