### PR TITLE
Add Kubernetes client connection and request timeout configs

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -287,6 +287,12 @@ object LivyConf {
   val KUBERNETES_CLIENT_CERT_FILE = Entry("livy.server.kubernetes.clientCertFile", "")
   // Kubernetes client default namespace.
   val KUBERNETES_DEFAULT_NAMESPACE = Entry("livy.server.kubernetes.defaultNamespace", "")
+  // Kubernetes client connection timeout
+  val KUBERNETES_CLIENT_CONNECTION_TIMEOUT =
+    Entry("livy.server.kubernetes.client.connection-timeout", "10s")
+  // Kubernetes client request timeout
+  val KUBERNETES_CLIENT_REQUEST_TIMEOUT =
+    Entry("livy.server.kubernetes.client.request-timeout", "10s")
 
   // Comma-separated list of the Kubernetes namespaces to allow for applications creation.
   // All namespaces are allowed if empty.

--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -460,6 +460,10 @@ private[utils] object KubernetesClientFactory {
     val clientKeyFile = livyConf.get(LivyConf.KUBERNETES_CLIENT_KEY_FILE).toOption
     val clientCertFile = livyConf.get(LivyConf.KUBERNETES_CLIENT_CERT_FILE).toOption
     val clientNamespace = livyConf.get(LivyConf.KUBERNETES_DEFAULT_NAMESPACE).toOption
+    val clientConnectionTimeout =
+      livyConf.getTimeAsMs(LivyConf.KUBERNETES_CLIENT_CONNECTION_TIMEOUT).asInstanceOf[Int]
+    val clientRequestTimeout =
+      livyConf.getTimeAsMs(LivyConf.KUBERNETES_CLIENT_REQUEST_TIMEOUT).asInstanceOf[Int]
 
     val config = new ConfigBuilder()
       .withApiVersion("v1")
@@ -482,6 +486,8 @@ private[utils] object KubernetesClientFactory {
       .withOption(clientNamespace) {
         (namespace, builder) => builder.withNamespace(namespace)
       }
+      .withConnectionTimeout(clientConnectionTimeout)
+      .withRequestTimeout(clientRequestTimeout)
       .build()
     new LivyKubernetesClient(
       new DefaultKubernetesClient(config), livyConf)


### PR DESCRIPTION
The default Kubernetes client connection and request timeout is 10s. We should support overriding the timeouts in a heavy loaded cluster.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
